### PR TITLE
Update gitignore bower_components path

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,4 +1,4 @@
 node_modules
 .tmp
 .sass-cache
-app/bower_components
+assets/bower_components


### PR DESCRIPTION
`bower_components` is located at `assets/bower_components` by default.
