### PR TITLE
Fix Error Which Caused Incorrect Port to Be Logged at Startup

### DIFF
--- a/app/templates/app.js
+++ b/app/templates/app.js
@@ -65,5 +65,6 @@ app.get('/', function(request, response, next) {
 /*
  * Start it up
  */
-app.listen(process.env.PORT || port);
+var port = process.env.PORT || port;
+app.listen(port);
 console.log('Express started on port ' + port);


### PR DESCRIPTION
If you override the port using the `PORT` environment variable, the overriden port number is not displayed in the log (it still says "Express started on port 3000", even if it the overridden port is _not_ 3000). This PR fixes that, so the correct port number is logged.
